### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "nodemon src/app.js"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JavaScript Boilerplate
 
+[![Run on Repl.it](https://repl.it/badge/github/bspeidel/nodejs-boilerplate)](https://repl.it/github/bspeidel/nodejs-boilerplate)
+
 starter kit for NodeJS development.
 
 ## Some features


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@netx/nodejs-boilerplate).